### PR TITLE
torchvision v0.11.1 to match pytorch v1.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.11.2" %}
+{% set version = "0.11.1" %}
 # waiting for https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1890
 {% set pytorch_version = "1.10.0" %}
 # see github.com/conda-forge/conda-forge.github.io/issues/1059 for naming discussion
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://github.com/pytorch/vision/archive/v{{ version }}.tar.gz
-  sha256: 55689c57c29f82438a133d0af3315991037be59c8e02471bdcaa31731154a714
+  sha256: 32a06ccf755e4d75006ce03701f207652747a63dbfdf65f0f20a1b6f93a2e834
   patches:
     - patches/0001-avoid-hard-coded-gcc.patch
 


### PR DESCRIPTION
- updated v0.11.1
- MNT: Re-rendered with conda-build 3.21.4, conda-smithy 3.13.0, and conda-forge-pinning 2021.10.21.11.39.39
- Update meta.yaml
- Delete recipe/patches directory
- Update meta.yaml
- test in verbose and pin pytorch better
- Explain wy we are skipping tests
- lint
- Add pytest-mock
- Update meta.yaml
- Delete the models tests to skip it.
- updated v0.11.2
- minor cleanup
- MNT: Re-rendered with conda-build 3.21.7, conda-smithy 3.16.0, and conda-forge-pinning 2021.12.20.19.09.43
- build with ffmpeg
- add patch to avoid hard-coded GCC
- MNT: Re-rendered with conda-build 3.21.7, conda-smithy 3.16.1, and conda-forge-pinning 2022.01.20.12.50.15
- Justify which tests we are skipping
- Skip more tests
- Skip a few more tests specifically for osx
- Run more of the test suite
- try v0.11.1 based on PR #35
