### PR TITLE
`cuda-version` host requirement v0.19.x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,8 @@ requirements:
     # - numpy
     - pip
     - setuptools
-    - cudnn                                  # [cuda_compiler_version != "None"]
+    - cudnn                                     # [cuda_compiler_version != "None"]
+    - cuda-version {{ cuda_compiler_version }}  # [(cuda_compiler_version or "None") != "None"]
     {% if cuda_major >= 12 %}
     - libcublas-dev
     - libcusolver-dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,9 @@ source:
     # backport https://github.com/pytorch/vision/pull/8776
     - patches/0006-Fix-pyav-14-error-8776.patch
 
+    # backport https://github.com/pytorch/vision/pull/8580
+    - patches/0007-fbsync-Skip-flaky-test_autocast_cpu-test-8580.patch
+
 build:
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version == "None"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ source:
 build:
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version == "None"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
-  number: 2
+  number: 3
   script_env:
     # required by the setup.py script to find the right version in 0.20.1
     - BUILD_VERSION={{ version }}

--- a/recipe/patches/0001-Monkeypatch-TORCH_LIB_PATH.patch
+++ b/recipe/patches/0001-Monkeypatch-TORCH_LIB_PATH.patch
@@ -1,7 +1,7 @@
 From dff0af81d2989e64a7cbb85b2611a1626d8200f3 Mon Sep 17 00:00:00 2001
 From: Uwe Korn <uwelk@xhochy.com>
 Date: Wed, 21 Jun 2023 19:13:57 +0000
-Subject: [PATCH 1/6] Monkeypatch TORCH_LIB_PATH
+Subject: [PATCH 1/7] Monkeypatch TORCH_LIB_PATH
 
 ---
  setup.py | 5 +++++
@@ -14,12 +14,12 @@ index c0c1050f..5ba04566 100644
 @@ -11,6 +11,11 @@ from pkg_resources import DistributionNotFound, get_distribution, parse_version
  from setuptools import find_packages, setup
  from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDA_HOME, CUDAExtension
- 
+
 +import site
 +import torch.utils.cpp_extension
 +
 +torch.utils.cpp_extension.TORCH_LIB_PATH = site.getsitepackages()[0] + '/torch/lib'
 +
- 
+
  def read(*names, **kwargs):
      with open(os.path.join(os.path.dirname(__file__), *names), encoding=kwargs.get("encoding", "utf8")) as fp:

--- a/recipe/patches/0002-Unvendor-giflib.patch
+++ b/recipe/patches/0002-Unvendor-giflib.patch
@@ -1,7 +1,7 @@
 From c81ffce3a7c083d5db9980cecd54b92a9c8f9582 Mon Sep 17 00:00:00 2001
 From: Mark Harfouche <mark.harfouche@gmail.com>
 Date: Sat, 24 Aug 2024 18:37:36 -0400
-Subject: [PATCH 2/6] Unvendor giflib
+Subject: [PATCH 2/7] Unvendor giflib
 
 ---
  setup.py                                     | 3 ++-
@@ -18,7 +18,7 @@ index 5ba04566..faab505c 100644
          + glob.glob(os.path.join(image_path, "cpu", "*.cpp"))
 -        + glob.glob(os.path.join(image_path, "cpu", "giflib", "*.c"))
      )
- 
+
 +    image_link_flags.append("gif")
 +
      if is_rocm_pytorch:
@@ -33,6 +33,6 @@ index 183d42e8..b806f335 100644
  #include <cstring>
 -#include "giflib/gif_lib.h"
 +#include <gif_lib.h>
- 
+
  namespace vision {
  namespace image {

--- a/recipe/patches/0003-Support-nvjpeg-at-conda-forge.patch
+++ b/recipe/patches/0003-Support-nvjpeg-at-conda-forge.patch
@@ -1,7 +1,7 @@
 From 6222a74d5748b72f1bdb18f3ee19f0f9f7686d94 Mon Sep 17 00:00:00 2001
 From: Mark Harfouche <mark.harfouche@gmail.com>
 Date: Sat, 24 Aug 2024 18:38:27 -0400
-Subject: [PATCH 3/6] Support nvjpeg at conda-forge
+Subject: [PATCH 3/7] Support nvjpeg at conda-forge
 
 ---
  setup.py | 10 +++-------
@@ -14,7 +14,7 @@ index faab505c..de37536d 100644
 @@ -316,13 +316,9 @@ def get_extensions():
          print("Building torchvision without JPEG image support")
      image_macros += [("JPEG_FOUND", str(int(use_jpeg)))]
- 
+
 -    # Locating nvjpeg
 -    # Should be included in CUDA_HOME for CUDA >= 10.1, which is the minimum version we have in the CI
 -    nvjpeg_found = (
@@ -25,6 +25,6 @@ index faab505c..de37536d 100644
 +    # conda-forge supports cross compilation of nvjpeg whic isn't
 +    # Really supported upstream
 +    nvjpeg_found = torch.cuda.is_available() or force_cuda
- 
+
      use_nvjpeg = use_nvjpeg and nvjpeg_found
      if use_nvjpeg:

--- a/recipe/patches/0004-Skip-OSS-CI-tests-as-well-in-conda-forge-azure.patch
+++ b/recipe/patches/0004-Skip-OSS-CI-tests-as-well-in-conda-forge-azure.patch
@@ -1,7 +1,7 @@
 From c7e16dbf815db951ecaebdf2f6947ddf974d6748 Mon Sep 17 00:00:00 2001
 From: Mark Harfouche <mark.harfouche@gmail.com>
 Date: Sun, 25 Aug 2024 09:12:29 -0400
-Subject: [PATCH 4/6] Skip OSS CI tests as well in conda-forge azure
+Subject: [PATCH 4/7] Skip OSS CI tests as well in conda-forge azure
 
 ---
  test/common_utils.py | 2 ++
@@ -12,8 +12,8 @@ index 99c79315..59768c59 100644
 --- a/test/common_utils.py
 +++ b/test/common_utils.py
 @@ -25,6 +25,8 @@ from torchvision.transforms.v2.functional import to_image, to_pil_image
- 
- 
+
+
  IN_OSS_CI = any(os.getenv(var) == "true" for var in ["CIRCLECI", "GITHUB_ACTIONS"])
 +# conda-forge defines the CI variable
 +IN_OSS_CI = IN_OSS_CI or (os.getenv('CI') == 'azure')

--- a/recipe/patches/0005-no-strict-transforms-warning.patch
+++ b/recipe/patches/0005-no-strict-transforms-warning.patch
@@ -1,7 +1,7 @@
 From daa4f4d8ee40cd09e1d6630799d73161374c567f Mon Sep 17 00:00:00 2001
 From: Mark Harfouche <mark.harfouche@gmail.com>
 Date: Sat, 24 Aug 2024 19:06:59 -0400
-Subject: [PATCH 5/6] no strict transforms warning
+Subject: [PATCH 5/7] no strict transforms warning
 
 ---
  test/test_transforms_v2.py | 9 ---------
@@ -13,8 +13,8 @@ index 07e3d75d..1a9c3475 100644
 +++ b/test/test_transforms_v2.py
 @@ -53,15 +53,6 @@ from torchvision.transforms.v2.functional._geometry import _get_perspective_coef
  from torchvision.transforms.v2.functional._utils import _get_kernel, _register_kernel_internal
- 
- 
+
+
 -# turns all warnings into errors for this module
 -pytestmark = [pytest.mark.filterwarnings("error")]
 -

--- a/recipe/patches/0006-Fix-pyav-14-error-8776.patch
+++ b/recipe/patches/0006-Fix-pyav-14-error-8776.patch
@@ -1,7 +1,7 @@
 From 396e220829f9d06d4c2259e98fe907cafada7d98 Mon Sep 17 00:00:00 2001
 From: Nicolas Hug <nh.nicolas.hug@gmail.com>
 Date: Mon, 2 Dec 2024 17:11:38 +0000
-Subject: [PATCH 6/6] Fix pyav 14 error (#8776)
+Subject: [PATCH 6/7] Fix pyav 14 error (#8776)
 
 ---
  torchvision/io/video.py | 22 ++++++++++++++++------
@@ -23,7 +23,7 @@ index 9b2eacba..0c72e68b 100644
      av = ImportError(
          """\
 @@ -129,7 +133,13 @@ def write_video(
- 
+
          for img in video_array:
              frame = av.VideoFrame.from_ndarray(img, format="rgb24")
 -            frame.pict_type = "NONE"
@@ -36,7 +36,7 @@ index 9b2eacba..0c72e68b 100644
 +
              for packet in stream.encode(frame):
                  container.mux(packet)
- 
+
 @@ -189,7 +199,7 @@ def _read_from_stream(
      try:
          # TODO check if stream needs to always be the video stream here or not
@@ -58,12 +58,12 @@ index 9b2eacba..0c72e68b 100644
 @@ -316,7 +326,7 @@ def read_video(
                      )
                      info["audio_fps"] = container.streams.audio[0].rate
- 
+
 -        except av.AVError:
 +        except FFmpegError:
              # TODO raise a warning?
              pass
- 
+
 @@ -399,10 +409,10 @@ def read_video_timestamps(filename: str, pts_unit: str = "pts") -> Tuple[List[in
                  video_time_base = video_stream.time_base
                  try:
@@ -76,4 +76,3 @@ index 9b2eacba..0c72e68b 100644
 +    except FFmpegError as e:
          msg = f"Failed to open container for {filename}; Caught error: {e}"
          warnings.warn(msg, RuntimeWarning)
- 

--- a/recipe/patches/0007-fbsync-Skip-flaky-test_autocast_cpu-test-8580.patch
+++ b/recipe/patches/0007-fbsync-Skip-flaky-test_autocast_cpu-test-8580.patch
@@ -1,0 +1,34 @@
+From ee39d63fe527427eb70f55a90f0f9987e20596a5 Mon Sep 17 00:00:00 2001
+From: Nicolas Hug <nicolashug@meta.com>
+Date: Thu, 15 Aug 2024 06:13:14 -0700
+Subject: [PATCH 7/7] [fbsync] Skip flaky test_autocast_cpu test (#8580)
+
+Reviewed By: ahmadsharif1
+
+Differential Revision: D61331607
+
+fbshipit-source-id: cb66215023ea77336b9d16180c362cba3dde6201
+---
+ test/test_ops.py | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/test/test_ops.py b/test/test_ops.py
+index 99b259f73f..22ba0ce2d5 100644
+--- a/test/test_ops.py
++++ b/test/test_ops.py
+@@ -507,11 +507,13 @@ class TestRoIAlign(RoIOpTester):
+                 rois_dtype=rois_dtype,
+             )
+
++    @pytest.mark.skip(reason="1/5000 flaky failure")
+     @pytest.mark.parametrize("aligned", (True, False))
+     @pytest.mark.parametrize("deterministic", (True, False))
+     @pytest.mark.parametrize("x_dtype", (torch.float, torch.bfloat16))
+     @pytest.mark.parametrize("rois_dtype", (torch.float, torch.bfloat16))
+     def test_autocast_cpu(self, aligned, deterministic, x_dtype, rois_dtype):
++
+         with torch.cpu.amp.autocast():
+             self.test_forward(
+                 torch.device("cpu"),
+--
+2.47.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Closes #112 

<!--
Please add any other relevant info below:
-->
Add cuda-version to constrain the related cuda libraries to the same version as the cuda compiler during the build per https://github.com/conda-forge/conda-forge.github.io/issues/1963

