### PR TITLE
`cuda-version` host requirement main

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,6 +16,12 @@ else
   export FORCE_CUDA=1
 fi
 
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" == "1" ]]; then
+  # Fix wrong (build) architecture being set instead of host architecture
+  CFLAGS="$(echo ${CFLAGS} | sed 's/ -march=[^ ]*//g' | sed 's/ -mcpu=[^ ]*//g' |sed 's/ -mtune=[^ ]*//g')"
+  CXXFLAGS="$(echo ${CXXFLAGS} | sed 's/ -march=[^ ]*//g' | sed 's/ -mcpu=[^ ]*//g' |sed 's/ -mtune=[^ ]*//g')"
+fi
+
 # remove pyproject.toml
 rm -f pyproject.toml
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -133,7 +133,7 @@ outputs:
         - setuptools
         - if: cuda_compiler_version != "None"
           then:
-            - cuda-version {{ cuda_compiler_version }}
+            - cuda-version ==${{ cuda_compiler_version }}
             - cudnn
             - libcublas-dev
             - libcusolver-dev

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   version: 0.20.1
-  build_number: 4
+  build_number: 5
   # see github.com/conda-forge/conda-forge.github.io/issues/1059 for naming discussion
   # torchvision requires that CUDA major and minor versions match with pytorch
   # https://github.com/pytorch/vision/blob/fa99a5360fbcd1683311d57a76fcc0e7323a4c1e/torchvision/extension.py#L79C1-L85C1
@@ -133,6 +133,7 @@ outputs:
         - setuptools
         - if: cuda_compiler_version != "None"
           then:
+            - cuda-version {{ cuda_compiler_version }}
             - cudnn
             - libcublas-dev
             - libcusolver-dev


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
closes #112

<!--
Please add any other relevant info below:
-->

Add cuda-version to constrain the related cuda libraries to the same version as the cuda compiler during the build per conda-forge/conda-forge.github.io#1963

