### PR TITLE
fix: use the CF_TORCH_CUDA_ARCH_LIST set by pytorch activation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @h-vetinari @hmaarrfk @nehaljwani
+* @h-vetinari @hmaarrfk @nehaljwani @ruben-arts

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -11,6 +11,8 @@ source .scripts/logging_utils.sh
 
 set -xeo pipefail
 
+DOCKER_EXECUTABLE="${DOCKER_EXECUTABLE:-docker}"
+
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename "$THISDIR")"
 
@@ -27,7 +29,7 @@ if [[ "${sha:-}" == "" ]]; then
   popd
 fi
 
-docker info
+${DOCKER_EXECUTABLE} info
 
 # In order for the conda-build process in the container to write to the mounted
 # volumes, we need to run with the same id as the host machine, which is
@@ -35,6 +37,7 @@ docker info
 export HOST_USER_ID=$(id -u)
 # Check if docker-machine is being used (normally on OSX) and get the uid from
 # the VM
+
 if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
     export HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
 fi
@@ -76,16 +79,34 @@ if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
-( endgroup "Configure Docker" ) 2> /dev/null
+# Default volume suffix for Docker (preserve original behavior)
+VOLUME_SUFFIX=",z"
 
+# Podman-specific handling
+if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
+    # Fix file permissions for rootless podman builds
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${ARTIFACTS}"
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${RECIPE_ROOT}"
+
+    # Add SELinux label only if enforcing
+    if command -v getenforce &>/dev/null && [ "$(getenforce)" = "Enforcing" ]; then
+        VOLUME_SUFFIX=",z"
+    else
+        VOLUME_SUFFIX=""
+    fi
+fi
+
+( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 export IS_PR_BUILD="${IS_PR_BUILD:-False}"
-docker pull "${DOCKER_IMAGE}"
-docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
+
+${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
+
+${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/README.md
+++ b/README.md
@@ -581,4 +581,5 @@ Feedstock Maintainers
 * [@h-vetinari](https://github.com/h-vetinari/)
 * [@hmaarrfk](https://github.com/hmaarrfk/)
 * [@nehaljwani](https://github.com/nehaljwani/)
+* [@ruben-arts](https://github.com/ruben-arts/)
 

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -11,14 +11,13 @@ set "TORCHVISION_USE_HEIC=1"
 set "TORCHVISION_USE_FFMPEG=0"
 
 if not "%cuda_compiler_version%" == "None" (
-    if "%cuda_compiler_version:~0,2%"=="12" (
-        set "TORCH_CUDA_ARCH_LIST=5.0;6.0;7.0;7.5;8.0;8.6;8.9;9.0;10.0;12.0+PTX"
-    ) else if "%cuda_compiler_version%" == "13.0" (
-        set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;8.9;9.0;10.0;11.0;12.0+PTX"
-    ) else (
-        echo "unsupported cuda version. edit build.bat"
+    REM CF_TORCH_CUDA_ARCH_LIST is set by pytorch's activation scripts to match the arch list pytorch was built with.
+    REM See https://github.com/conda-forge/pytorch-cpu-feedstock/blob/main/recipe/activate.sh
+    if "%CF_TORCH_CUDA_ARCH_LIST%" == "" (
+        echo CF_TORCH_CUDA_ARCH_LIST is not set. Ensure the correct pytorch is installed and its activation scripts have run.
         exit /b 1
     )
+    set "TORCH_CUDA_ARCH_LIST=%CF_TORCH_CUDA_ARCH_LIST%"
 
     set FORCE_CUDA=1
     set TORCHVISION_USE_NVJPEG=1

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -18,6 +18,7 @@ if not "%cuda_compiler_version%" == "None" (
         exit /b 1
     )
     set "TORCH_CUDA_ARCH_LIST=%CF_TORCH_CUDA_ARCH_LIST%"
+    echo TORCH_CUDA_ARCH_LIST is set to %TORCH_CUDA_ARCH_LIST%
 
     set FORCE_CUDA=1
     set TORCHVISION_USE_NVJPEG=1

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -11,15 +11,15 @@ set "TORCHVISION_USE_HEIC=1"
 set "TORCHVISION_USE_FFMPEG=0"
 
 if not "%cuda_compiler_version%" == "None" (
-    REM CF_TORCH_CUDA_ARCH_LIST is set by pytorch's activation scripts to match the arch list pytorch was built with.
-    REM See https://github.com/conda-forge/pytorch-cpu-feedstock/blob/main/recipe/activate.sh
-    if "%CF_TORCH_CUDA_ARCH_LIST%" == "" (
-        echo CF_TORCH_CUDA_ARCH_LIST is not set. Ensure the correct pytorch is installed and its activation scripts have run.
-        exit 1
+    if "%cuda_compiler_version:~0,2%"=="12" (
+        set "TORCH_CUDA_ARCH_LIST=5.0;6.0;7.0;7.5;8.0;8.6;8.9;9.0;10.0;12.0+PTX"
+    ) else if "%cuda_compiler_version%" == "13.0" (
+        set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;8.9;9.0;10.0;11.0;12.0+PTX"
+    ) else (
+        echo "unsupported cuda version. edit build.bat"
+        exit /b 1
     )
-    set "TORCH_CUDA_ARCH_LIST=%CF_TORCH_CUDA_ARCH_LIST%"
-    echo TORCH_CUDA_ARCH_LIST is set to %TORCH_CUDA_ARCH_LIST%
-
+    
     set FORCE_CUDA=1
     set TORCHVISION_USE_NVJPEG=1
 ) else (

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -19,7 +19,6 @@ if not "%cuda_compiler_version%" == "None" (
         echo "unsupported cuda version. edit build.bat"
         exit /b 1
     )
-    
     set FORCE_CUDA=1
     set TORCHVISION_USE_NVJPEG=1
 ) else (

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -15,7 +15,7 @@ if not "%cuda_compiler_version%" == "None" (
     REM See https://github.com/conda-forge/pytorch-cpu-feedstock/blob/main/recipe/activate.sh
     if "%CF_TORCH_CUDA_ARCH_LIST%" == "" (
         echo CF_TORCH_CUDA_ARCH_LIST is not set. Ensure the correct pytorch is installed and its activation scripts have run.
-        exit /b 1
+        exit 1
     )
     set "TORCH_CUDA_ARCH_LIST=%CF_TORCH_CUDA_ARCH_LIST%"
     echo TORCH_CUDA_ARCH_LIST is set to %TORCH_CUDA_ARCH_LIST%

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -19,6 +19,7 @@ if not "%cuda_compiler_version%" == "None" (
         echo "unsupported cuda version. edit build.bat"
         exit /b 1
     )
+
     set FORCE_CUDA=1
     set TORCHVISION_USE_NVJPEG=1
 ) else (

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,7 +17,7 @@ else
     fi
     # Due to a change in the supported CUDA architectures, we need to replace 10.1 with 11.0 in the arch list if it is present.
     # See: https://github.com/conda-forge/pytorch-cpu-feedstock/issues/494
-    export TORCH_CUDA_ARCH_LIST="${CF_TORCH_CUDA_ARCH_LIST//10.1/11.0}"
+    export TORCH_CUDA_ARCH_LIST="${CF_TORCH_CUDA_ARCH_LIST}"
   fi
   echo "TORCH_CUDA_ARCH_LIST is set to ${TORCH_CUDA_ARCH_LIST}"
   export FORCE_CUDA=1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,15 +5,13 @@ if [[ "$cuda_compiler_version" == "None" ]]; then
   export FORCE_CUDA=0
 else
   export CUDA_TOOLKIT_ROOT_DIR="${PREFIX}"
-  if [[ ${cuda_compiler_version} == 12.9 ]]; then
-      export TORCH_CUDA_ARCH_LIST="5.0;6.0;7.0;7.5;8.0;8.6;8.9;9.0;10.0;12.0+PTX"
-      export CUDA_TOOLKIT_ROOT_DIR="${PREFIX}"
-  elif [[ ${cuda_compiler_version} == 13.0 ]]; then
-      export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;8.9;9.0;10.0;11.0;12.0+PTX"
-  else
-      echo "unsupported cuda version. edit build.sh"
-      exit 1
+  # CF_TORCH_CUDA_ARCH_LIST is set by pytorch's activation scripts to match the arch list pytorch was built with.
+  # See https://github.com/conda-forge/pytorch-cpu-feedstock/blob/main/recipe/activate.sh
+  if [[ -z "${CF_TORCH_CUDA_ARCH_LIST:-}" ]]; then
+    echo "CF_TORCH_CUDA_ARCH_LIST is not set. Ensure the correct pytorch is installed and its activation scripts have run."
+    exit 1
   fi
+  export TORCH_CUDA_ARCH_LIST="${CF_TORCH_CUDA_ARCH_LIST}"
   export FORCE_CUDA=1
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,7 +11,9 @@ else
     echo "CF_TORCH_CUDA_ARCH_LIST is not set. Ensure the correct pytorch is installed and its activation scripts have run."
     exit 1
   fi
-  export TORCH_CUDA_ARCH_LIST="${CF_TORCH_CUDA_ARCH_LIST}"
+  # Due to a change in the supported CUDA architectures, we need to replace 10.1 with 11.0 in the arch list if it is present.
+  # See: https://github.com/conda-forge/pytorch-cpu-feedstock/issues/494
+  export TORCH_CUDA_ARCH_LIST="${CF_TORCH_CUDA_ARCH_LIST//10.1/11.0}"
   echo "TORCH_CUDA_ARCH_LIST is set to ${TORCH_CUDA_ARCH_LIST}"
   export FORCE_CUDA=1
 fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,15 +5,20 @@ if [[ "$cuda_compiler_version" == "None" ]]; then
   export FORCE_CUDA=0
 else
   export CUDA_TOOLKIT_ROOT_DIR="${PREFIX}"
-  # CF_TORCH_CUDA_ARCH_LIST is set by pytorch's activation scripts to match the arch list pytorch was built with.
-  # See https://github.com/conda-forge/pytorch-cpu-feedstock/blob/main/recipe/activate.sh
-  if [[ -z "${CF_TORCH_CUDA_ARCH_LIST:-}" ]]; then
-    echo "CF_TORCH_CUDA_ARCH_LIST is not set. Ensure the correct pytorch is installed and its activation scripts have run."
-    exit 1
+  if [[ "${arm_variant_type:-}" == "tegra" ]]; then
+    # Tegra (Jetson) devices only support sm_87, so we hardcode the arch list.
+    export TORCH_CUDA_ARCH_LIST="8.7+PTX"
+  else
+    # CF_TORCH_CUDA_ARCH_LIST is set by pytorch's activation scripts to match the arch list pytorch was built with.
+    # See https://github.com/conda-forge/pytorch-cpu-feedstock/blob/main/recipe/activate.sh
+    if [[ -z "${CF_TORCH_CUDA_ARCH_LIST:-}" ]]; then
+      echo "CF_TORCH_CUDA_ARCH_LIST is not set. Ensure the correct pytorch is installed and its activation scripts have run."
+      exit 1
+    fi
+    # Due to a change in the supported CUDA architectures, we need to replace 10.1 with 11.0 in the arch list if it is present.
+    # See: https://github.com/conda-forge/pytorch-cpu-feedstock/issues/494
+    export TORCH_CUDA_ARCH_LIST="${CF_TORCH_CUDA_ARCH_LIST//10.1/11.0}"
   fi
-  # Due to a change in the supported CUDA architectures, we need to replace 10.1 with 11.0 in the arch list if it is present.
-  # See: https://github.com/conda-forge/pytorch-cpu-feedstock/issues/494
-  export TORCH_CUDA_ARCH_LIST="${CF_TORCH_CUDA_ARCH_LIST//10.1/11.0}"
   echo "TORCH_CUDA_ARCH_LIST is set to ${TORCH_CUDA_ARCH_LIST}"
   export FORCE_CUDA=1
 fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,6 +12,7 @@ else
     exit 1
   fi
   export TORCH_CUDA_ARCH_LIST="${CF_TORCH_CUDA_ARCH_LIST}"
+  echo "TORCH_CUDA_ARCH_LIST is set to ${TORCH_CUDA_ARCH_LIST}"
   export FORCE_CUDA=1
 fi
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   version: "0.25.0"
-  build_number: 4
+  build_number: 5
   # see github.com/conda-forge/conda-forge.github.io/issues/1059 for naming discussion
   # torchvision requires that CUDA major and minor versions match with pytorch
   # https://github.com/pytorch/vision/blob/fa99a5360fbcd1683311d57a76fcc0e7323a4c1e/torchvision/extension.py#L79C1-L85C1

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -218,4 +218,5 @@ extra:
     - nehaljwani
     - hmaarrfk
     - h-vetinari
+    - ruben-arts # special interest in Jetson/Tegra builds
   feedstock-name: torchvision


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

This PR changes that `torchvision`'s build script sets the `TORCH_CUDA_ARCH_LIST` variable for compilation and uses the one set by the `pytorch` package's activation script. This way the two will not be out of sync, as what happened through the [PR](https://github.com/conda-forge/torchvision-feedstock/pull/151) I made.

Related but not fixed: #154 
We should do another pass when pytorch has the fixes in.